### PR TITLE
parametrize secondary ipv4 range

### DIFF
--- a/pkg/controller/infrastructure/infraflow/ensure.go
+++ b/pkg/controller/infrastructure/infraflow/ensure.go
@@ -126,6 +126,7 @@ func (fctx *FlowContext) ensureSubnet(ctx context.Context) error {
 		vpc.SelfLink,
 		fctx.config.Networks.FlowLogs,
 		fctx.config.Networks.DualStack,
+		fctx.networking.Pods,
 	)
 
 	subnet, err := fctx.computeClient.GetSubnet(ctx, region, subnetName)
@@ -168,7 +169,6 @@ func (fctx *FlowContext) ensureInternalSubnet(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-
 	desired := targetSubnetState(
 		subnetName,
 		"gardener-managed internal subnet",
@@ -176,6 +176,7 @@ func (fctx *FlowContext) ensureInternalSubnet(ctx context.Context) error {
 		vpc.SelfLink,
 		nil,
 		fctx.config.Networks.DualStack,
+		nil,
 	)
 	if subnet == nil {
 		subnet, err = fctx.computeClient.InsertSubnet(ctx, region, desired)
@@ -220,6 +221,7 @@ func (fctx *FlowContext) ensureServicesSubnet(ctx context.Context) error {
 		vpc.SelfLink,
 		nil,
 		fctx.config.Networks.DualStack,
+		nil,
 	)
 	if subnet == nil {
 		subnet, err = fctx.computeClient.InsertSubnet(ctx, region, desired)

--- a/pkg/controller/infrastructure/infraflow/ensure_utils.go
+++ b/pkg/controller/infrastructure/infraflow/ensure_utils.go
@@ -99,7 +99,7 @@ func targetNetwork(name string) *compute.Network {
 	}
 }
 
-func targetSubnetState(name, description, cidr, networkName string, flowLogs *gcp.FlowLogs, dualStack *gcp.DualStack) *compute.Subnetwork {
+func targetSubnetState(name, description, cidr, networkName string, flowLogs *gcp.FlowLogs, dualStack *gcp.DualStack, secondaryRange *string) *compute.Subnetwork {
 	subnet := &compute.Subnetwork{
 		Description:           description,
 		PrivateIpGoogleAccess: false,
@@ -113,9 +113,12 @@ func targetSubnetState(name, description, cidr, networkName string, flowLogs *gc
 	if dualStack.Enabled {
 		subnet.Ipv6AccessType = "EXTERNAL"
 		subnet.StackType = "IPV4_IPV6"
+	}
+
+	if secondaryRange != nil {
 		subnet.SecondaryIpRanges = []*compute.SubnetworkSecondaryRange{
 			{
-				IpCidrRange: "192.168.0.0/16",
+				IpCidrRange: *secondaryRange,
 				RangeName:   "ipv4-pod-cidr",
 			},
 		}

--- a/pkg/controller/infrastructure/infraflow/ensure_utils.go
+++ b/pkg/controller/infrastructure/infraflow/ensure_utils.go
@@ -113,14 +113,13 @@ func targetSubnetState(name, description, cidr, networkName string, flowLogs *gc
 	if dualStack.Enabled {
 		subnet.Ipv6AccessType = "EXTERNAL"
 		subnet.StackType = "IPV4_IPV6"
-	}
-
-	if secondaryRange != nil {
-		subnet.SecondaryIpRanges = []*compute.SubnetworkSecondaryRange{
-			{
-				IpCidrRange: *secondaryRange,
-				RangeName:   "ipv4-pod-cidr",
-			},
+		if secondaryRange != nil {
+			subnet.SecondaryIpRanges = []*compute.SubnetworkSecondaryRange{
+				{
+					IpCidrRange: *secondaryRange,
+					RangeName:   "ipv4-pod-cidr",
+				},
+			}
 		}
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

This PR will parametrize the secondary ipv4 range and will make the function that responsible for ensuring the subnet object creates the secondary ipv4 range if it's only necessary

/area TODO
/kind TODO
/platform gcp

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
