### PR TITLE
Enable dual-stack on validation

### DIFF
--- a/pkg/apis/gcp/validation/shoot.go
+++ b/pkg/apis/gcp/validation/shoot.go
@@ -28,10 +28,6 @@ func ValidateNetworking(networking *core.Networking, fldPath *field.Path) field.
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("ipFamilies"), networking.IPFamilies, "IPv6 single-stack networking is not supported"))
 	}
 
-	if len(networking.IPFamilies) > 1 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("ipFamilies"), networking.IPFamilies, "dual-stack networking is not supported"))
-	}
-
 	return allErrs
 }
 

--- a/pkg/apis/gcp/validation/shoot_test.go
+++ b/pkg/apis/gcp/validation/shoot_test.go
@@ -17,7 +17,7 @@ import (
 
 var _ = Describe("Shoot validation", func() {
 	Describe("#ValidateNetworking", func() {
-		var networkingPath = field.NewPath("spec", "networking")
+		networkingPath := field.NewPath("spec", "networking")
 
 		It("should return no error because nodes CIDR was provided", func() {
 			networking := &core.Networking{
@@ -40,6 +40,20 @@ var _ = Describe("Shoot validation", func() {
 					"Field": Equal("spec.networking.nodes"),
 				})),
 			))
+		})
+
+		It("should pass dual-stack", func() {
+			networking := &core.Networking{
+				Nodes: ptr.To("1.2.3.4/5"),
+				IPFamilies: []core.IPFamily{
+					core.IPFamilyIPv4,
+					core.IPFamilyIPv6,
+				},
+			}
+
+			errorList := ValidateNetworking(networking, networkingPath)
+
+			Expect(errorList).To(BeEmpty())
 		})
 	})
 	Describe("#ValidateWorkers", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area TODO
/kind TODO
/platform gcp

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
