### PR TITLE
Provide correct --service-cluster-ip-range to kube-apiserver and kube-controllermanager

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -467,11 +467,11 @@ func (vp *valuesProvider) getCCMChartValues(
 		values["featureGates"] = cpConfig.CloudControllerManager.FeatureGates
 	}
 
-	ok, err := vp.isOverlayEnabled(cluster.Shoot.Spec.Networking)
+	overlayEnabled, err := vp.isOverlayEnabled(cluster.Shoot.Spec.Networking)
 	if err != nil {
 		return nil, err
 	}
-	values["configureCloudRoutes"] = !ok
+	values["configureCloudRoutes"] = !overlayEnabled || !isDualstackEnabled(cluster.Shoot.Spec.Networking)
 
 	return values, nil
 }

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -7,7 +7,9 @@ package controlplane
 import (
 	"bytes"
 	"context"
+	"net"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -105,7 +107,7 @@ func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, gctx gconte
 	}
 
 	if c := extensionswebhook.ContainerWithName(ps.Containers, "kube-apiserver"); c != nil {
-		ensureKubeAPIServerCommandLineArgs(c, k8sVersion)
+		ensureKubeAPIServerCommandLineArgs(c, k8sVersion, cluster.Shoot.Status.Networking.Services)
 	}
 
 	return nil
@@ -127,7 +129,7 @@ func (e *ensurer) EnsureKubeControllerManagerDeployment(ctx context.Context, gct
 	}
 
 	if c := extensionswebhook.ContainerWithName(ps.Containers, "kube-controller-manager"); c != nil {
-		ensureKubeControllerManagerCommandLineArgs(c, k8sVersion)
+		ensureKubeControllerManagerCommandLineArgs(c, k8sVersion, cluster.Shoot.Status.Networking.Services)
 		ensureKubeControllerManagerVolumeMounts(c)
 	}
 
@@ -178,7 +180,7 @@ func (e *ensurer) EnsureClusterAutoscalerDeployment(ctx context.Context, gctx gc
 	return nil
 }
 
-func ensureKubeAPIServerCommandLineArgs(c *corev1.Container, k8sVersion *semver.Version) {
+func ensureKubeAPIServerCommandLineArgs(c *corev1.Container, k8sVersion *semver.Version, servicesIPRanges []string) {
 	if versionutils.ConstraintK8sLess127.Check(k8sVersion) {
 		c.Command = extensionswebhook.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",
 			"CSIMigration=true", ",")
@@ -200,15 +202,12 @@ func ensureKubeAPIServerCommandLineArgs(c *corev1.Container, k8sVersion *semver.
 		c.Command = extensionswebhook.EnsureStringWithPrefixContains(c.Command, "--disable-admission-plugins=",
 			"PersistentVolumeLabel", ",")
 	}
-	for i, v := range c.Args {
-		if strings.Contains(v, "--service-cluster-ip-range") {
-			c.Args = append(c.Args[:i], c.Args[i+1:]...)
-		}
-	}
-	c.Args = append(c.Args, "--service-cluster-ip-range=10.96.0.0/12,fd00::/108")
+
+	c.Args = extensionswebhook.EnsureNoStringWithPrefix(c.Args, "--service-cluster-ip-range=")
+	c.Args = append(c.Args, "--service-cluster-ip-range="+normalizeServicesIPRanges(servicesIPRanges))
 }
 
-func ensureKubeControllerManagerCommandLineArgs(c *corev1.Container, k8sVersion *semver.Version) {
+func ensureKubeControllerManagerCommandLineArgs(c *corev1.Container, k8sVersion *semver.Version, servicesIPRanges []string) {
 	c.Command = extensionswebhook.EnsureStringWithPrefix(c.Command, "--cloud-provider=", "external")
 
 	if versionutils.ConstraintK8sLess127.Check(k8sVersion) {
@@ -227,8 +226,27 @@ func ensureKubeControllerManagerCommandLineArgs(c *corev1.Container, k8sVersion 
 	c.Command = extensionswebhook.EnsureNoStringWithPrefix(c.Command, "--external-cloud-volume-plugin=")
 	c.Command = extensionswebhook.EnsureNoStringWithPrefix(c.Command, "--allocate-node-cidrs=")
 	c.Command = append(c.Command, "--allocate-node-cidrs=false")
-	// c.Command = extensionswebhook.EnsureNoStringWithPrefix(c.Command, "--service-cluster-ip-range=")
-	// c.Command = append(c.Command, "--service-cluster-ip-range=10.96.0.0/12,fd00::/108")
+	c.Command = extensionswebhook.EnsureNoStringWithPrefix(c.Command, "--service-cluster-ip-range=")
+	c.Command = append(c.Command, "--service-cluster-ip-range="+normalizeServicesIPRanges(servicesIPRanges))
+}
+
+// normalizeServicesIPRanges rewrites found IPv6 subnet masks to /108
+func normalizeServicesIPRanges(netRanges []string) string {
+	ranges := slices.Clone(netRanges)
+
+	for i, ipnet := range ranges {
+		_, nt, err := net.ParseCIDR(ipnet)
+		if err != nil {
+			continue
+		}
+
+		if len(nt.IP) == net.IPv6len {
+			nt.Mask = net.CIDRMask(108, net.IPv6len*8)
+			ranges[i] = nt.String()
+		}
+	}
+
+	return strings.Join(ranges, ",")
 }
 
 func ensureKubeSchedulerCommandLineArgs(c *corev1.Container, k8sVersion *semver.Version) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area TODO
/kind TODO
/platform gcp

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
