### PR TITLE
Subnets & firewalls

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -442,6 +442,11 @@ func (vp *valuesProvider) getCCMChartValues(
 		return nil, fmt.Errorf("secret %q not found", cloudControllerManagerServerName)
 	}
 
+	overlayEnabled, err := vp.isOverlayEnabled(cluster.Shoot.Spec.Networking)
+	if err != nil {
+		return nil, err
+	}
+
 	values := map[string]interface{}{
 		"enabled":           true,
 		"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
@@ -461,17 +466,18 @@ func (vp *valuesProvider) getCCMChartValues(
 			"server": serverSecret.Name,
 		},
 		"gep19Monitoring": gep19Monitoring,
+		"configureCloudRoutes": func() bool {
+			if isDualstackEnabled(cluster.Shoot.Spec.Networking) {
+				return false
+			}
+
+			return !overlayEnabled
+		}(),
 	}
 
 	if cpConfig.CloudControllerManager != nil {
 		values["featureGates"] = cpConfig.CloudControllerManager.FeatureGates
 	}
-
-	overlayEnabled, err := vp.isOverlayEnabled(cluster.Shoot.Spec.Networking)
-	if err != nil {
-		return nil, err
-	}
-	values["configureCloudRoutes"] = !overlayEnabled || !isDualstackEnabled(cluster.Shoot.Spec.Networking)
 
 	return values, nil
 }

--- a/pkg/controller/infrastructure/infraflow/ensure.go
+++ b/pkg/controller/infrastructure/infraflow/ensure.go
@@ -383,8 +383,8 @@ func (fctx *FlowContext) ensureFirewallRules(ctx context.Context) error {
 
 	if len(cidrsipv6) > 0 {
 		rules = append(rules,
-			firewallRuleAllowInternal(firewallRuleAllowInternalName(fctx.clusterName)+"-ipv6", vpc.SelfLink, cidrsipv6),
-			firewallRuleAllowHealthChecks(firewallRuleAllowHealthChecksName(fctx.clusterName)+"-ipv6", vpc.SelfLink, healthCheckSourceRangesIPv6),
+			firewallRuleAllowInternalIPv6(firewallRuleAllowInternalNameIPv6(fctx.clusterName), vpc.SelfLink, cidrsipv6),
+			firewallRuleAllowHealthChecks(firewallRuleAllowHealthChecksNameIPv6(fctx.clusterName), vpc.SelfLink, healthCheckSourceRangesIPv6),
 		)
 	}
 

--- a/pkg/controller/infrastructure/infraflow/ensure.go
+++ b/pkg/controller/infrastructure/infraflow/ensure.go
@@ -374,11 +374,11 @@ func (fctx *FlowContext) ensureFirewallRules(ctx context.Context) error {
 	}
 
 	cidrsipv6 := []*string{}
-	if nodesipv6 := GetObject[string](fctx.whiteboard, NodesSubnetIPv6CIDR); nodesipv6 != "" {
-		cidrsipv6 = append(cidrsipv6, ptr.To(nodesipv6))
+	if nodesipv6 := fctx.whiteboard.Get(NodesSubnetIPv6CIDR); ptr.Deref(nodesipv6, "") != "" {
+		cidrsipv6 = append(cidrsipv6, nodesipv6)
 	}
-	if servicesipv6 := GetObject[string](fctx.whiteboard, ServicesSubnetIPv6CIDR); servicesipv6 != "" {
-		cidrsipv6 = append(cidrsipv6, ptr.To(servicesipv6))
+	if servicesipv6 := fctx.whiteboard.Get(ServicesSubnetIPv6CIDR); ptr.Deref(servicesipv6, "") != "" {
+		cidrsipv6 = append(cidrsipv6, servicesipv6)
 	}
 
 	if len(cidrsipv6) > 0 {

--- a/pkg/controller/infrastructure/infraflow/ensure.go
+++ b/pkg/controller/infrastructure/infraflow/ensure.go
@@ -165,7 +165,7 @@ func (fctx *FlowContext) ensureInternalSubnet(ctx context.Context) error {
 	region := fctx.infra.Spec.Region
 
 	if fctx.config.Networks.Internal == nil {
-		return fctx.ensureSubnetDeletedFabrica(fctx.internalSubnetNameFromConfig(), ObjectKeyInternalSubnet)(ctx)
+		return fctx.ensureSubnetDeletedFactory(fctx.internalSubnetNameFromConfig(), ObjectKeyInternalSubnet)(ctx)
 	}
 
 	if err := fctx.ensureObjectKeys(ObjectKeyVPC); err != nil {
@@ -420,11 +420,11 @@ func (fctx *FlowContext) ensureVPCDeleted(ctx context.Context) error {
 	return nil
 }
 
-func (fctx *FlowContext) ensureSubnetDeletedFabrica(subnetName string, whiteboardKey string) func(context.Context) error {
+func (fctx *FlowContext) ensureSubnetDeletedFactory(subnetName string, whiteboardKey string) func(context.Context) error {
 	return func(ctx context.Context) error {
 		log := shared.LogFromContext(ctx)
 
-		log.Info("deleting %s subnet", subnetName)
+		log.Info("deleting", "subnet", subnetName)
 		err := fctx.computeClient.DeleteSubnet(ctx, fctx.infra.Spec.Region, subnetName)
 		if err != nil {
 			return err
@@ -512,7 +512,7 @@ func (fctx *FlowContext) ensureFirewallRulesDeleted(ctx context.Context) error {
 	}
 
 	for _, fw := range fws {
-		log.Info(fmt.Sprintf("destroying firewall rule [name=%s]", fw.Name))
+		log.Info("destroying firewall rule", "name", fw.Name)
 		err := fctx.computeClient.DeleteFirewallRule(ctx, fw.Name)
 		if err != nil {
 			return err
@@ -543,7 +543,7 @@ func (fctx *FlowContext) ensureKubernetesRoutesDeleted(ctx context.Context) erro
 	}
 
 	for _, route := range routes {
-		log.Info(fmt.Sprintf("destroying route[name=%s]", route.Name))
+		log.Info("destroying route", "name", route.Name)
 		err := fctx.computeClient.DeleteRoute(ctx, route.Name)
 		if err != nil {
 			return err

--- a/pkg/controller/infrastructure/infraflow/ensure.go
+++ b/pkg/controller/infrastructure/infraflow/ensure.go
@@ -369,7 +369,18 @@ func (fctx *FlowContext) ensureFirewallRules(ctx context.Context) error {
 	}
 	vpc := GetObject[*compute.Network](fctx.whiteboard, ObjectKeyVPC)
 
-	cidrs := []*string{fctx.podCIDR, fctx.config.Networks.Internal, ptr.To(fctx.config.Networks.Workers), ptr.To(fctx.config.Networks.Worker)}
+	cidrs := []*string{
+		fctx.podCIDR,
+		fctx.config.Networks.Internal,
+		ptr.To(fctx.config.Networks.Workers),
+		ptr.To(fctx.config.Networks.Worker),
+	}
+	if nodesipv6 := GetObject[string](fctx.whiteboard, NodesSubnetIPv6CIDR); nodesipv6 != "" {
+		cidrs = append(cidrs, ptr.To(nodesipv6))
+	}
+	if servicesipv6 := GetObject[string](fctx.whiteboard, ServicesSubnetIPv6CIDR); servicesipv6 != "" {
+		cidrs = append(cidrs, ptr.To(servicesipv6))
+	}
 	rules := []*compute.Firewall{
 		firewallRuleAllowInternal(firewallRuleAllowInternalName(fctx.clusterName), vpc.SelfLink, cidrs),
 		firewallRuleAllowHealthChecks(firewallRuleAllowHealthChecksName(fctx.clusterName), vpc.SelfLink),

--- a/pkg/controller/infrastructure/infraflow/ensure_utils.go
+++ b/pkg/controller/infrastructure/infraflow/ensure_utils.go
@@ -283,21 +283,29 @@ func firewallRuleAllowExternal(name, network string) *compute.Firewall {
 	}
 }
 
-func firewallRuleAllowHealthChecks(name, network string) *compute.Firewall {
+// Following ranges documented at https://cloud.google.com/load-balancing/docs/health-check-concepts#ip-ranges
+var (
+	healthCheckSourceRangesIPv4 = []string{
+		"35.191.0.0/16",
+		"209.85.204.0/22",
+		"209.85.152.0/22",
+		"130.211.0.0/22",
+	}
+
+	healthCheckSourceRangesIPv6 = []string{
+		"2600:2d00:1:b029::/64",
+		"2600:2d00:1:1::/64",
+		"2600:1901:8001::/48",
+	}
+)
+
+func firewallRuleAllowHealthChecks(name, network string, cidrs []string) *compute.Firewall {
 	return &compute.Firewall{
-		Name:      name,
-		Network:   network,
-		Direction: "INGRESS",
-		Priority:  1000,
-		SourceRanges: []string{
-			"35.191.0.0/16",
-			"209.85.204.0/22",
-			"209.85.152.0/22",
-			"130.211.0.0/22",
-			"2600:2d00:1:b029::/64",
-			"2600:2d00:1:1::/64",
-			"2600:1901:8001::/48",
-		},
+		Name:         name,
+		Network:      network,
+		Direction:    "INGRESS",
+		Priority:     1000,
+		SourceRanges: cidrs,
 		Allowed: []*compute.FirewallAllowed{
 			{
 				IPProtocol: "udp",

--- a/pkg/controller/infrastructure/infraflow/ensure_utils.go
+++ b/pkg/controller/infrastructure/infraflow/ensure_utils.go
@@ -294,6 +294,9 @@ func firewallRuleAllowHealthChecks(name, network string) *compute.Firewall {
 			"209.85.204.0/22",
 			"209.85.152.0/22",
 			"130.211.0.0/22",
+			"2600:2d00:1:b029::/64",
+			"2600:2d00:1:1::/64",
+			"2600:1901:8001::/48",
 		},
 		Allowed: []*compute.FirewallAllowed{
 			{

--- a/pkg/controller/infrastructure/infraflow/graph.go
+++ b/pkg/controller/infrastructure/infraflow/graph.go
@@ -38,10 +38,12 @@ func (fctx *FlowContext) buildReconcileGraph() *flow.Graph {
 	ensureServicesSubnet := fctx.AddTask(g, "ensure IPv6 services subnet", fctx.ensureServicesSubnet,
 		shared.Timeout(defaultCreateTimeout),
 		shared.Dependencies(ensureVPC),
+		shared.DoIf(fctx.config.Networks.DualStack != nil && fctx.config.Networks.DualStack.Enabled),
 	)
 	fctx.AddTask(g, "ensure IPv6 CIDR services", fctx.ensureIPv6CIDRs,
 		shared.Timeout(defaultCreateTimeout),
 		shared.Dependencies(ensureNodesSubnet, ensureServicesSubnet),
+		shared.DoIf(fctx.config.Networks.DualStack != nil && fctx.config.Networks.DualStack.Enabled),
 	)
 	ensureRouter := fctx.AddTask(g, "ensure router", fctx.ensureCloudRouter,
 		shared.Timeout(defaultCreateTimeout),
@@ -77,8 +79,16 @@ func (fctx *FlowContext) buildDeleteGraph() *flow.Graph {
 		// we do not need to clean up CloudNAT for managed CloudRouters because it will be deleted with the router deletion.
 		shared.DoIf(isUserRouter(fctx.config)),
 	)
-	ensureInternalSubnetDeleted := fctx.AddTask(g, "destroy internal subnet", fctx.ensureInternalSubnetDeleted,
+	ensureInternalSubnetDeleted := fctx.AddTask(g,
+		"destroy internal subnet",
+		fctx.ensureSubnetDeletedFabrica(fctx.internalSubnetNameFromConfig(), ObjectKeyInternalSubnet),
 		shared.Timeout(defaultDeleteTimeout),
+	)
+	ensureServicesSubnetDeleted := fctx.AddTask(g,
+		"destroy services subnet",
+		fctx.ensureSubnetDeletedFabrica(fctx.servicesSubnetNameFromConfig(), ObjectKeyServicesSubnet),
+		shared.Timeout(defaultDeleteTimeout),
+		shared.DoIf(fctx.config.Networks.DualStack != nil && fctx.config.Networks.DualStack.Enabled),
 	)
 	ensureCloudRouterDeleted := fctx.AddTask(g, "ensure router deleted", fctx.ensureCloudRouterDeleted,
 		shared.Timeout(defaultDeleteTimeout),
@@ -86,13 +96,23 @@ func (fctx *FlowContext) buildDeleteGraph() *flow.Graph {
 		// for user-managed CloudRouters, skip deletion.
 		shared.DoIf(!isUserRouter(fctx.config)),
 	)
-	ensureSubnetDeleted := fctx.AddTask(g, "destroy worker subnet", fctx.ensureSubnetDeleted,
+	ensureSubnetDeleted := fctx.AddTask(g,
+		"destroy worker subnet",
+		fctx.ensureSubnetDeletedFabrica(fctx.subnetNameFromConfig(), ObjectKeyNodeSubnet),
 		shared.Timeout(defaultDeleteTimeout),
 		shared.Dependencies(ensureCloudRouterDeleted),
 	)
-	fctx.AddTask(g, "destroy vpc", fctx.ensureVPCDeleted,
+	fctx.AddTask(g,
+		"destroy vpc",
+		fctx.ensureVPCDeleted,
 		shared.Timeout(defaultDeleteTimeout),
-		shared.Dependencies(ensureSubnetDeleted, ensureInternalSubnetDeleted, ensureCloudRouterDeleted, ensureFirewallDeleted),
+		shared.Dependencies(
+			ensureSubnetDeleted,
+			ensureInternalSubnetDeleted,
+			ensureServicesSubnetDeleted,
+			ensureCloudRouterDeleted,
+			ensureFirewallDeleted,
+		),
 		shared.DoIf(!isUserVPC(fctx.config)),
 	)
 

--- a/pkg/controller/infrastructure/infraflow/graph.go
+++ b/pkg/controller/infrastructure/infraflow/graph.go
@@ -81,12 +81,12 @@ func (fctx *FlowContext) buildDeleteGraph() *flow.Graph {
 	)
 	ensureInternalSubnetDeleted := fctx.AddTask(g,
 		"destroy internal subnet",
-		fctx.ensureSubnetDeletedFabrica(fctx.internalSubnetNameFromConfig(), ObjectKeyInternalSubnet),
+		fctx.ensureSubnetDeletedFactory(fctx.internalSubnetNameFromConfig(), ObjectKeyInternalSubnet),
 		shared.Timeout(defaultDeleteTimeout),
 	)
 	ensureServicesSubnetDeleted := fctx.AddTask(g,
 		"destroy services subnet",
-		fctx.ensureSubnetDeletedFabrica(fctx.servicesSubnetNameFromConfig(), ObjectKeyServicesSubnet),
+		fctx.ensureSubnetDeletedFactory(fctx.servicesSubnetNameFromConfig(), ObjectKeyServicesSubnet),
 		shared.Timeout(defaultDeleteTimeout),
 		shared.DoIf(fctx.config.Networks.DualStack != nil && fctx.config.Networks.DualStack.Enabled),
 	)
@@ -98,7 +98,7 @@ func (fctx *FlowContext) buildDeleteGraph() *flow.Graph {
 	)
 	ensureSubnetDeleted := fctx.AddTask(g,
 		"destroy worker subnet",
-		fctx.ensureSubnetDeletedFabrica(fctx.subnetNameFromConfig(), ObjectKeyNodeSubnet),
+		fctx.ensureSubnetDeletedFactory(fctx.subnetNameFromConfig(), ObjectKeyNodeSubnet),
 		shared.Timeout(defaultDeleteTimeout),
 		shared.Dependencies(ensureCloudRouterDeleted),
 	)

--- a/pkg/controller/infrastructure/infraflow/graph.go
+++ b/pkg/controller/infrastructure/infraflow/graph.go
@@ -40,7 +40,7 @@ func (fctx *FlowContext) buildReconcileGraph() *flow.Graph {
 		shared.Dependencies(ensureVPC),
 		shared.DoIf(fctx.config.Networks.DualStack != nil && fctx.config.Networks.DualStack.Enabled),
 	)
-	fctx.AddTask(g, "ensure IPv6 CIDR services", fctx.ensureIPv6CIDRs,
+	ensureIPv6Services := fctx.AddTask(g, "ensure IPv6 CIDR services", fctx.ensureIPv6CIDRs,
 		shared.Timeout(defaultCreateTimeout),
 		shared.Dependencies(ensureNodesSubnet, ensureServicesSubnet),
 		shared.DoIf(fctx.config.Networks.DualStack != nil && fctx.config.Networks.DualStack.Enabled),
@@ -55,11 +55,11 @@ func (fctx *FlowContext) buildReconcileGraph() *flow.Graph {
 	)
 	fctx.AddTask(g, "ensure nats", fctx.ensureCloudNAT,
 		shared.Timeout(defaultCreateTimeout),
-		shared.Dependencies(ensureRouter, ensureNodesSubnet, ensureIpAddresses))
-
+		shared.Dependencies(ensureRouter, ensureNodesSubnet, ensureIpAddresses),
+	)
 	fctx.AddTask(g, "ensure firewall", fctx.ensureFirewallRules,
 		shared.Timeout(defaultCreateTimeout),
-		shared.Dependencies(ensureVPC, ensureNodesSubnet, ensureInternalSubnet),
+		shared.Dependencies(ensureVPC, ensureNodesSubnet, ensureInternalSubnet, ensureIPv6Services),
 	)
 
 	return g


### PR DESCRIPTION
* Add task to delete services subnet
* Add IPv6 node and services ranges in case they are configured
* Add IPv6 Source CIDRs to healthchecks firewall rules
* Create dedicated firewall rules for IPv6

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area TODO
/kind TODO
/platform gcp

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
